### PR TITLE
Adding the ability to not fetch on a useGet

### DIFF
--- a/src/useGet.test.tsx
+++ b/src/useGet.test.tsx
@@ -506,6 +506,27 @@ describe("useGet hook", () => {
     });
   });
 
+  describe("with skip", () => {
+    it("should not fetch", async () => {
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const MyAwesomeComponent = () => {
+        const { data, error, loading } = useGet<{ oh: string }>({ path: "/", skip: true });
+        return children({ data, error, loading });
+      };
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <MyAwesomeComponent />
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children).toBeCalledTimes(1));
+      expect(children).toHaveBeenCalledWith({ data: null, error: null, loading: true });
+    });
+  });
+
   describe("with base", () => {
     it("should override the base url", async () => {
       nock("https://my-awesome-api.fake")

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -52,6 +52,10 @@ export interface UseGetProps<TData, TError, TQueryParams, TPathParams> {
    */
   lazy?: boolean;
   /**
+   * Should we skip if this is true?
+   */
+  skip?: boolean;
+  /**
    * An escape hatch and an alternative to `path` when you'd like
    * to fetch from an entirely different URL.
    *
@@ -87,6 +91,11 @@ async function _fetchData<TData, TError, TQueryParams, TPathParams>(
     requestOptions,
     pathParams = {},
   } = props;
+
+  if (props.skip) {
+    abort();
+    return;
+  }
 
   if (state.loading) {
     // Abort previous requests
@@ -228,7 +237,7 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
   const [state, setState] = useState<GetState<TData, TError>>({
     data: null,
     response: null,
-    loading: !props.lazy,
+    loading: !props.lazy || !!props.skip,
     error: null,
   });
 
@@ -246,6 +255,7 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
     };
   }, [
     props.lazy,
+    props.skip,
     props.mock,
     props.path,
     props.base,


### PR DESCRIPTION
# Why

Adds the ability to skip, handy when missing a token or using this for authentication and don't want it to run without that data.
